### PR TITLE
Fix code scanning alert no. 7: Prototype-polluting assignment

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -216,6 +216,9 @@ export class PromptBuilder<I extends string, O extends string, T extends NodeDat
    * @throws {Error} - If the key is not found.
    */
   inputRaw<V = string | number | undefined>(key: string, value: V, encodeOs?: OSType) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error(`Invalid key: ${key}`);
+    }
     if (value !== undefined) {
       let valueToSet = value;
       /**


### PR DESCRIPTION
Fixes [https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/7](https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/7)

To fix the prototype pollution vulnerability, we need to ensure that the `key` parameter does not contain any dangerous values like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check at the beginning of the `inputRaw` method to reject such keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
