### PR TITLE
Fix code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -230,12 +230,15 @@ export class PromptBuilder<I extends string, O extends string, T extends NodeDat
       const keys = key.split(".");
       let current = this.prompt as any;
       for (let i = 0; i < keys.length - 1; i++) {
+        if (keys[i] === "__proto__" || keys[i] === "constructor") continue;
         if (!current[keys[i]]) {
           current[keys[i]] = {}; // Alow to set value to undefined path
         }
         current = current[keys[i]];
       }
-      current[keys[keys.length - 1]] = valueToSet;
+      if (keys[keys.length - 1] !== "__proto__" && keys[keys.length - 1] !== "constructor") {
+        current[keys[keys.length - 1]] = valueToSet;
+      }
     }
     return this as Simplify<PromptBuilder<I, O, T>>;
   }


### PR DESCRIPTION
Fixes [https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/6](https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/6)

To fix the problem, we need to ensure that the properties being assigned to the `current` object do not include special properties like `__proto__` or `constructor`. This can be achieved by adding a check to skip these properties during the assignment process.

1. Modify the `inputRaw` method to include a check that skips the assignment if the property name is `__proto__` or `constructor`.
2. Ensure that the rest of the functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
