### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -216,6 +216,9 @@ export class PromptBuilder<I extends string, O extends string, T extends NodeDat
    * @throws {Error} - If the key is not found.
    */
   inputRaw<V = string | number | undefined>(key: string, value: V, encodeOs?: OSType) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error(`Invalid key: ${key}`);
+    }
     if (value !== undefined) {
       let valueToSet = value;
       /**


### PR DESCRIPTION
Fixes [https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/1](https://github.com/comfy-addons/comfyui-sdk/security/code-scanning/1)

To fix the prototype pollution vulnerability, we need to ensure that the `key` parameter does not contain any values that can modify the `Object.prototype`. One way to achieve this is by validating the `key` parameter and rejecting any keys that are `__proto__`, `constructor`, or `prototype`.

We will add a validation step in the `inputRaw` method to check for these dangerous keys and throw an error if any of them are detected. This will prevent the prototype pollution vulnerability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
